### PR TITLE
Day20a

### DIFF
--- a/Day_20a/Day_20a.ino
+++ b/Day_20a/Day_20a.ino
@@ -1,0 +1,45 @@
+//identify how to show digits in specfiic spots on 7 segment display
+#include <TM1637Display.h>
+
+// Define the display connection pins:
+#define CLK 6
+#define DIO 5
+
+// Create display object of type TM1637Display:
+TM1637Display OurDisplay = TM1637Display(CLK, DIO);
+ 
+// Create array that turns all segments on:
+const uint8_t data[] = {0xff, 0xff, 0xff, 0xff};
+ 
+// Create array that turns all segments off:
+const uint8_t blank[] = {0x00, 0x00, 0x00, 0x00};
+ 
+int pw1 = 0;
+int pw2 = 2;
+int pw3 = 3;
+int pw4 = 4;
+
+void setup() {
+  // Setup Serial Monitor
+  Serial.begin(9600);
+
+  // Clear the display:
+  OurDisplay.clear();
+  delay(1000);
+  OurDisplay.setBrightness(7);
+}
+
+void loop() {
+  OurDisplay.showNumberDec(pw1,true,1,0);
+  delay(1000);
+  OurDisplay.clear();
+  OurDisplay.showNumberDec(((pw1*10)+pw2),true,2,0);
+  delay(1000);
+  OurDisplay.clear();
+  OurDisplay.showNumberDec(((pw1*100)+(pw2*10)+pw3),true,3,0);
+  delay(1000);
+  OurDisplay.clear();
+  OurDisplay.showNumberDec(((pw1*1000)+(pw2*100)+(pw3*10)+pw4),true,4,0);
+  delay(1000);
+  OurDisplay.clear();
+}

--- a/Day_20b/Day_20b.ino
+++ b/Day_20b/Day_20b.ino
@@ -1,0 +1,112 @@
+//use rotary encoder to cycle 0-9 and wrap
+#include <TM1637Display.h>
+
+// Define the display connection pins:
+#define CLK 11
+#define DIO 10
+
+// Rotary Encoder Inputs
+#define CLK2 3
+#define DT2 4
+// Switch Input
+#define SW2 2
+
+// Create display object of type TM1637Display:
+TM1637Display OurDisplay = TM1637Display(CLK, DIO);
+ 
+// Create array that turns all segments on:
+const uint8_t data[] = {0xff, 0xff, 0xff, 0xff};
+ 
+// Create array that turns all segments off:
+const uint8_t blank[] = {0x00, 0x00, 0x00, 0x00};
+ 
+int pw1 = 1;
+int pw2 = 2;
+int pw3 = 3;
+int pw4 = 4;
+
+int currentStateCLK;
+int lastStateCLK;
+
+void setup() {
+  // Setup Serial Monitor
+  Serial.begin(9600);
+
+  // Set encoder pins as inputs
+  pinMode(CLK2,INPUT);
+  pinMode(DT2,INPUT);
+  pinMode(SW2,INPUT_PULLUP);
+
+  pinMode(13, OUTPUT);
+ 
+  // Clear the display:
+  OurDisplay.clear();
+  delay(1000);
+  OurDisplay.setBrightness(7);
+
+  // Read the initial state of A (CLK)
+  lastStateCLK = digitalRead(CLK2);
+
+  // Call Interrupt Service Routine (ISR) updateEncoder() when any high/low change
+  // is seen on A (CLK2) interrupt  (pin 2), or B (DT2) interrupt (pin 3)
+  //hardware interrupts are only available on pins 2 and 3
+  attachInterrupt(digitalPinToInterrupt(CLK2), updateEncoder, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(SW2), flash, CHANGE);
+}
+
+void loop() {
+  OurDisplay.showNumberDec(pw1,true,1,0);
+  delay(10);
+  //Serial.println(digitalRead(SW2));
+  // OurDisplay.clear();
+}
+
+//  This is our ISR which has the job of responding to interrupt events
+void updateEncoder(){
+  // Read the current state of CLK
+  currentStateCLK = digitalRead(CLK2);
+ 
+  // If last and current state of CLK are different, then a pulse occurred;
+  // React to only 0->1 state change to avoid double counting
+  if (currentStateCLK != lastStateCLK  && currentStateCLK == 1){
+ 
+    // If the DT state is different than the CLK state then
+    // the encoder is rotating CW so INCREASE counter by 1
+    if (digitalRead(DT2) == currentStateCLK) {
+      if(pw1 == 9){
+        pw1 = 0;
+      }
+      else {
+        pw1 ++;
+      }
+     
+    } else {
+      // Encoder is rotating CCW so DECREASE counter by 1
+      if(pw1 == 0){
+        pw1 = 9;
+      }
+      else {
+        pw1 --;
+      }
+    }
+ 
+    // Serial.print("Direction: ");
+    // Serial.print(currentDir);
+    // Serial.print(" | Counter= ");
+    // Serial.println(counter);
+  }
+ 
+  // Remember last CLK state to use on next interrupt...
+  lastStateCLK = currentStateCLK;
+}
+
+//function makes onboard LED flash when button is pushed
+void flash(){
+  Serial.println("flash");
+  if(SW2 == HIGH){
+    digitalWrite(13, LOW);
+  }
+  else {
+    digitalWrite(13, HIGH);
+  }
+}

--- a/Day_20b/Day_20b.ino
+++ b/Day_20b/Day_20b.ino
@@ -13,20 +13,17 @@
 
 // Create display object of type TM1637Display:
 TM1637Display OurDisplay = TM1637Display(CLK, DIO);
- 
+
 // Create array that turns all segments on:
 const uint8_t data[] = {0xff, 0xff, 0xff, 0xff};
- 
+
 // Create array that turns all segments off:
 const uint8_t blank[] = {0x00, 0x00, 0x00, 0x00};
- 
-int pw1 = 0;
-// int pw2 = 2;
-// int pw3 = 3;
-// int pw4 = 4;  
-int length = 1;
-int password = 1111;
-int multiplier = 1;
+
+int pw1 = 1;
+int pw2 = 2;
+int pw3 = 3;
+int pw4 = 4;
 
 int currentStateCLK;
 int lastStateCLK;
@@ -41,7 +38,7 @@ void setup() {
   pinMode(SW2,INPUT_PULLUP);
 
   pinMode(13, OUTPUT);
- 
+
   // Clear the display:
   OurDisplay.clear();
   delay(1000);
@@ -54,11 +51,11 @@ void setup() {
   // is seen on A (CLK2) interrupt  (pin 2), or B (DT2) interrupt (pin 3)
   //hardware interrupts are only available on pins 2 and 3
   attachInterrupt(digitalPinToInterrupt(CLK2), updateEncoder, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(SW2), record, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(SW2), flash, CHANGE);
 }
 
 void loop() {
-  OurDisplay.showNumberDec(pw1,true,length,0);
+  OurDisplay.showNumberDec(pw1,true,1,0);
   delay(10);
   //Serial.println(digitalRead(SW2));
   // OurDisplay.clear();
@@ -68,11 +65,11 @@ void loop() {
 void updateEncoder(){
   // Read the current state of CLK
   currentStateCLK = digitalRead(CLK2);
- 
+
   // If last and current state of CLK are different, then a pulse occurred;
   // React to only 0->1 state change to avoid double counting
   if (currentStateCLK != lastStateCLK  && currentStateCLK == 1){
- 
+
     // If the DT state is different than the CLK state then
     // the encoder is rotating CW so INCREASE counter by 1
     if (digitalRead(DT2) == currentStateCLK) {
@@ -82,7 +79,7 @@ void updateEncoder(){
       else {
         pw1 ++;
       }
-     
+
     } else {
       // Encoder is rotating CCW so DECREASE counter by 1
       if(pw1 == 0){
@@ -92,24 +89,24 @@ void updateEncoder(){
         pw1 --;
       }
     }
- 
+
     // Serial.print("Direction: ");
     // Serial.print(currentDir);
     // Serial.print(" | Counter= ");
     // Serial.println(counter);
   }
- 
+
   // Remember last CLK state to use on next interrupt...
   lastStateCLK = currentStateCLK;
 }
 
 //function makes onboard LED flash when button is pushed
-void record(){
-  if (SW2 == HIGH){
-    password = pw1 * multiplier;
-    Serial.println(password);
-    multiplier = multiplier * 10;
-    length ++;
-    pw1 = pw1 * multiplier;
+void flash(){
+  Serial.println("flash");
+  if(SW2 == HIGH){
+    digitalWrite(13, LOW);
+  }
+  else {
+    digitalWrite(13, HIGH);
   }
 }

--- a/Day_20c/Day_20c.ino
+++ b/Day_20c/Day_20c.ino
@@ -1,4 +1,4 @@
-//use rotary encoder to cycle 0-9 and wrap
+//use rotary encoder to build four digit number
 #include <TM1637Display.h>
 
 // Define the display connection pins:
@@ -26,7 +26,7 @@ int pw1 = 0;
 // int pw4 = 4;  
 int length = 1;
 int password = 1111;
-int multiplier = 1;
+int multiplier = 10;
 
 int currentStateCLK;
 int lastStateCLK;
@@ -55,6 +55,17 @@ void setup() {
   //hardware interrupts are only available on pins 2 and 3
   attachInterrupt(digitalPinToInterrupt(CLK2), updateEncoder, CHANGE);
   attachInterrupt(digitalPinToInterrupt(SW2), record, CHANGE);
+
+  //debuging readout 
+  Serial.print("pw1: ");
+  Serial.print(pw1);
+  Serial.print("  length: ");
+  Serial.print(length);
+  Serial.print("  password: ");
+  Serial.print(password);
+  Serial.print("  multiplier: ");
+  Serial.println(multiplier);
+
 }
 
 void loop() {
@@ -76,8 +87,8 @@ void updateEncoder(){
     // If the DT state is different than the CLK state then
     // the encoder is rotating CW so INCREASE counter by 1
     if (digitalRead(DT2) == currentStateCLK) {
-      if(pw1 == 9){
-        pw1 = 0;
+      if((pw1 - (password * multiplier)) == 9){
+        pw1 = password * multiplier;
       }
       else {
         pw1 ++;
@@ -85,8 +96,8 @@ void updateEncoder(){
      
     } else {
       // Encoder is rotating CCW so DECREASE counter by 1
-      if(pw1 == 0){
-        pw1 = 9;
+      if(pw1 == (password * multiplier)){
+        pw1 = pw1 + 9;
       }
       else {
         pw1 --;
@@ -105,11 +116,27 @@ void updateEncoder(){
 
 //function makes onboard LED flash when button is pushed
 void record(){
-  if (SW2 == HIGH){
-    password = pw1 * multiplier;
-    Serial.println(password);
-    multiplier = multiplier * 10;
+    Serial.println(digitalRead(SW2));
+  if (digitalRead(SW2) == LOW){
+    Serial.println("in loop");
+    password = pw1;
+    //multiplier = multiplier * 10;
+    if (length < 4) {
     length ++;
     pw1 = pw1 * multiplier;
+    }
+  //debuging readout 
+    Serial.print("pw1: ");
+    Serial.print(pw1);
+    Serial.print("  length: ");
+    Serial.print(length);
+    Serial.print("  password: ");
+    Serial.print(password);
+    Serial.print("  multiplier: ");
+    Serial.println(multiplier);
+  }
+  if (length == 5){
+    pw1 = password;
+    length == 4;
   }
 }

--- a/Day_20c/Day_20c.ino
+++ b/Day_20c/Day_20c.ino
@@ -2,8 +2,10 @@
 #include <TM1637Display.h>
 
 // Define the display connection pins:
-#define CLK 11
-#define DIO 10
+//#define CLK 11
+//#define DIO 10
+#define CLK 7
+#define DIO 6
 
 // Rotary Encoder Inputs
 #define CLK2 3

--- a/Day_20d/.theia/launch.json
+++ b/Day_20d/.theia/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "cwd": "${workspaceFolder}",
+      "executable": "./bin/executable.elf",
+      "name": "Debug with ST-Link",
+      "request": "launch",
+      "type": "cortex-debug",
+      "runToEntryPoint": "main",
+      "showDevDebugOutput": "none",
+      "servertype": "stlink"
+    },
+  {
+    "cwd": "${workspaceRoot}",
+    "executable": "./bin/executable.elf",
+    "name": "Debug with OpenOCD",
+    "request": "launch",
+    "type": "cortex-debug",
+    "servertype": "openocd",
+    "configFiles": [],
+    "searchDir": [],
+    "runToEntryPoint": "main",
+    "showDevDebugOutput": "none"
+  }
+  ]
+}

--- a/Day_20d/Day_20d.ino
+++ b/Day_20d/Day_20d.ino
@@ -206,7 +206,7 @@ void passwordChange() {
   }
   OurDisplay.clear();
   showMenu();
-  Serial.println("Change Password");
+  //Serial.println("Change Password");
   access = 1;
   result = 'X';
   return(0);
@@ -317,7 +317,7 @@ void loop() {
   if (access == 1){
     //Serial.println("You have entered the menu");
     showMenu();
-    Serial.println("In Loop, Access == 1");
+    //Serial.println("In Loop, Access == 1");
   }
 
   while (access == 1) {           // enter menu mode
@@ -438,17 +438,17 @@ void updateEncoder(){
 
 //function makes onboard LED flash when button is pushed
 void record(){
-  Serial.print("Access: ");
-  Serial.println(access);
-  if (access > 0){
-  Serial.print("MenuOption: ");
-  Serial.println(menuOption);
-  }
-  Serial.println(digitalRead(SW2));
+  // Serial.print("Access: ");
+  // Serial.println(access);
+  // if (access > 0){
+  // Serial.print("MenuOption: ");
+  // Serial.println(menuOption);
+  // }
+  //Serial.println(digitalRead(SW2));
 
   if (access <= 0)  {   //actions while validating password
     if (digitalRead(SW2) == HIGH){
-      Serial.println("in loop");
+      //Serial.println("in loop");
       pw2 = pw1;
       //multiplier = multiplier * 10;
       if (length == 4){ //entering of password complete, validate if correct
@@ -460,13 +460,18 @@ void record(){
           OurDisplay.clear();
           if (result == 'X'){
             showMenu();
-            Serial.println("In record, password verified, result == X");
+            //Serial.println("In record, password verified, result == X");
           }
           return(0);
         }
         else {
-          Serial.println("Fuck off imposter!");
-          Serial.println("Enter the correct password to access the system:");
+          if (result =='C'){
+            Serial.println("Nope");
+          }
+          else {
+            Serial.println("Fuck off imposter!");
+            Serial.println("Enter the correct password to access the system:");
+          }
           pw1 = 0;
           pw2 = 0;
           length = 1;
@@ -480,22 +485,22 @@ void record(){
       pw1 = pw1 * multiplier;
       }
     //debuging readout 
-      Serial.print("pw1: ");
-      Serial.print(pw1);
-      Serial.print("  pw2: ");
-      Serial.print(pw2);
-      Serial.print("  length: ");
-      Serial.print(length);
-      Serial.print("  password: ");
-      Serial.print(password);
-      Serial.print("  multiplier: ");
-      Serial.println(multiplier);
+      // Serial.print("pw1: ");
+      // Serial.print(pw1);
+      // Serial.print("  pw2: ");
+      // Serial.print(pw2);
+      // Serial.print("  length: ");
+      // Serial.print(length);
+      // Serial.print("  password: ");
+      // Serial.print(password);
+      // Serial.print("  multiplier: ");
+      // Serial.println(multiplier);
     }
   }
   
   if (access == 1 && digitalRead(SW2) == HIGH){  //while in the main menu
-    Serial.print("MenuOption: ");
-    Serial.println(menuOption);
+    // Serial.print("MenuOption: ");
+    // Serial.println(menuOption);
     //Serial.println("Add select a menu option");
     switch (menuOption) {
       case 'A':
@@ -540,7 +545,7 @@ void record(){
     result = 'Y';
     delay(10);
     showMenu();
-    Serial.println("exit menu A or B, Access was 2, now == 1");
+    //Serial.println("exit menu A or B, Access was 2, now == 1");
   }
   if (access == 3 && digitalRead(SW2) == HIGH){  //switch operation while resetting password
     length ++;

--- a/Day_20d/Day_20d.ino
+++ b/Day_20d/Day_20d.ino
@@ -36,6 +36,7 @@ const uint8_t eChar[] = {SEG_A | SEG_D | SEG_E | SEG_F | SEG_G};
 
 //  menu option currently being displayed
 char menuOption = 'X';
+char result = 'X';
 
 int pw1 = 0;
 int pw2 = 0;
@@ -191,7 +192,7 @@ void passwordChange() {
   RGB_color(0, 0, 0);
 }
 */
-/*
+
 void menuOptA(){
   int sensorValue = 0;
   int buzzTone = 100;
@@ -213,7 +214,7 @@ void menuOptA(){
     noTone(buzzer);
     delay(10);
   }
-  return;
+  return(0);
 }
 
 void menuOptB(){
@@ -257,9 +258,9 @@ void menuOptB(){
 
   }
   RGB_color(0,0,0);
-  return;
+  return(0);
 } 
-*/
+
 void loop() {
  
  if (access <= 0){
@@ -285,32 +286,32 @@ void loop() {
 
   while (access > 0) {           // enter menu mode
     //result = securityPad.getKey(); 
-    Serial.println("In the menu loop"); 
-    delay(2000);
-    /*
-    while(!(result = securityPad.getKey())) {
+    //Serial.println("In the menu loop"); 
+    delay(1);
+    
+    //while(!(result = securityPad.getKey())) {
          // wait indefinitely for keypad input of any kind
-       }
+       //}
     //Serial.println(result);
     if (result == 'A'){
       //Serial.println("This is option A.");
       menuOptA();
-      showMenu();
+      //showMenu();
     }
     if (result == 'B'){
       //Serial.println("This is option B");
       menuOptB();
-      showMenu();
+      //showMenu();
     }
     if (result == 'C'){
       Serial.println("Enter the new password:");
-      passwordChange();
-      showMenu();
+      //passwordChange();
+      //showMenu();
     }
-    if (result == '9'){
-      access = -1;
-      Serial.println("Exiting the system");
-    } */
+    // if (result == 'E'){
+    //   access = -1;
+    //   Serial.println("Exiting the system");
+    // } 
   }
 }
  
@@ -346,7 +347,7 @@ void updateEncoder(){
     lastStateCLK = currentStateCLK;
   }
   if (access > 0) {   //actions after password has been validated and system access has been granted
-    Serial.println("Here you need to code to scroll through the menu options");
+    //Serial.println("Here you need to code to scroll through the menu options");
     if (currentStateCLK != lastStateCLK  && currentStateCLK == 1){
       if (digitalRead(DT2) == currentStateCLK) {
         switch (menuOption) {
@@ -402,6 +403,10 @@ void updateEncoder(){
 void record(){
   Serial.print("Access: ");
   Serial.println(access);
+  if (access > 0){
+  Serial.print("MenuOption: ");
+  Serial.println(menuOption);
+  }
   Serial.println(digitalRead(SW2));
 
   if (access <= 0)  {   //actions while validating password
@@ -416,7 +421,7 @@ void record(){
           Serial.println("Looks Good");
           access = 1;
           OurDisplay.clear();
-          exit(0);
+          return(0);
         }
         else {
           Serial.println("Fuck off imposter!");
@@ -445,31 +450,40 @@ void record(){
       Serial.println(multiplier);
     }
   }
-  /*
+  
   if (access == 1 && digitalRead(SW2) == HIGH){  //while in the main menu
-    Serial.println("Add select a menu option");
+    Serial.print("MenuOption: ");
+    Serial.println(menuOption);
+    //Serial.println("Add select a menu option");
     switch (menuOption) {
       case 'A':
+        Serial.println("Option A");
         access = 2;
         OurDisplay.clear();
-        menuOptA();
-        break;
+        //menuOptA();
+        result = 'A';
+        return(0);
       case 'B':
+        Serial.println("Option B");
         access = 2;
         OurDisplay.clear();
-        menuOptB();
-        break;
+        //menuOptA();
+        result = 'B';
+        return(0);
       case 'C':
+        Serial.println("Option C");
         access = 2;
         OurDisplay.clear();
-        //passwordChange();
-        break;
+        //menuOptA();
+        result = 'C';
+        return(0);
       case 'E':
         access = 0;
         pw1 = 0;
         pw2 = 0;
         length = 1;
         OurDisplay.clear();
+        Serial.println("System exited");
         Serial.println("Enter password to access the system:");
         break;
       default:
@@ -477,13 +491,14 @@ void record(){
         break;
     }
   }
-  */
-  /*
+  
+  
   if (access == 2 && digitalRead(SW2) == HIGH){  //while you are inside of a menu option
-    Serial.println("Add return to the menu state");
+    //Serial.println("Add return to the menu state");
     access = 1;
+    result = 'Y';
     delay(10);
     showMenu();
   }
-  */
+  
 }

--- a/Day_20d/Day_20d.ino
+++ b/Day_20d/Day_20d.ino
@@ -348,7 +348,7 @@ void updateEncoder(){
 //function makes onboard LED flash when button is pushed
 void record(){
     Serial.println(digitalRead(SW2));
-  if (digitalRead(SW2) == LOW){
+  if (digitalRead(SW2) == HIGH){
     Serial.println("in loop");
     pw2 = pw1;
     //multiplier = multiplier * 10;
@@ -357,7 +357,7 @@ void record(){
       //pw1 = pw2;
       //length = 4;
       if (pw1 == password){
-        Serial.println("Look Good");
+        Serial.println("Looks Good");
         access = 1;
         OurDisplay.clear();
       }

--- a/Day_20d/Day_20d.ino
+++ b/Day_20d/Day_20d.ino
@@ -151,11 +151,11 @@ void setup() {
   attachInterrupt(digitalPinToInterrupt(SW2), record, CHANGE);
 
   RGB_color(125, 125, 125);  //set LED to white on startup...
-  delay(2000);
+  delay(1000);
   RGB_color(0, 0, 0);  //... and off again
  
   Serial.begin(9600); // Begin monitoring via the serial monitor
-  delay(2000);
+  delay(1000);
   // Serial.println("Enter password to access the system:");
   // Serial.println("Press * to set a new password.");
   // Serial.println("Press # to access the system with the existing one.");
@@ -177,7 +177,6 @@ void passwordChange() {
     while(!(result = securityPad.getKey())) {
     // wait indefinitely for keypad input of any kind
     }
-
     currentPassword[i] = result;
     Serial.print("*");    // print a phantom character for a successful keystroke
     playInput();
@@ -185,21 +184,20 @@ void passwordChange() {
     delay(100);
     RGB_color(0, 0, 0);
   }   //  done after 4 characters are accepted
-
   Serial.println("");
   Serial.println("Password Successfully Changed!");
   RGB_color(0, 125, 0); // LED to GREEN
   delay(2000);
   RGB_color(0, 0, 0);
-
 }
-
+*/
+/*
 void menuOptA(){
   int sensorValue = 0;
   int buzzTone = 100;
   float senPercent = 0.0;
-  Serial.println("Press any key to return to menu.");
-  while(!(result = securityPad.getKey())) {
+  Serial.println("Press the button to return to menu.");
+  while(access == 2) {
     // run photo sound operation until a key is pressed
     sensorValue = analogRead(sensorPin);
     senPercent = (float)sensorValue / (float)senMax;
@@ -225,8 +223,8 @@ void menuOptB(){
   int redLevel;
   int greenLevel;
   int blueLevel;
-  Serial.println("Press any key to return to menu.");
-  while(!(result = securityPad.getKey())) {
+  Serial.println("Press button to return to menu.");
+  while(access == 2) {
     // run photo sound operation until a key is pressed
     sensorValue = analogRead(sensorPin);
     senPercent = (float)sensorValue / (float)senMax;
@@ -260,8 +258,8 @@ void menuOptB(){
   }
   RGB_color(0,0,0);
   return;
-} */
-
+} 
+*/
 void loop() {
  
  if (access <= 0){
@@ -402,6 +400,8 @@ void updateEncoder(){
 
 //function makes onboard LED flash when button is pushed
 void record(){
+  Serial.print("Access: ");
+  Serial.println(access);
   Serial.println(digitalRead(SW2));
 
   if (access <= 0)  {   //actions while validating password
@@ -416,6 +416,7 @@ void record(){
           Serial.println("Looks Good");
           access = 1;
           OurDisplay.clear();
+          exit(0);
         }
         else {
           Serial.println("Fuck off imposter!");
@@ -444,10 +445,45 @@ void record(){
       Serial.println(multiplier);
     }
   }
+  /*
   if (access == 1 && digitalRead(SW2) == HIGH){  //while in the main menu
     Serial.println("Add select a menu option");
+    switch (menuOption) {
+      case 'A':
+        access = 2;
+        OurDisplay.clear();
+        menuOptA();
+        break;
+      case 'B':
+        access = 2;
+        OurDisplay.clear();
+        menuOptB();
+        break;
+      case 'C':
+        access = 2;
+        OurDisplay.clear();
+        //passwordChange();
+        break;
+      case 'E':
+        access = 0;
+        pw1 = 0;
+        pw2 = 0;
+        length = 1;
+        OurDisplay.clear();
+        Serial.println("Enter password to access the system:");
+        break;
+      default:
+        Serial.println("Select a menu option");
+        break;
+    }
   }
+  */
+  /*
   if (access == 2 && digitalRead(SW2) == HIGH){  //while you are inside of a menu option
     Serial.println("Add return to the menu state");
+    access = 1;
+    delay(10);
+    showMenu();
   }
+  */
 }

--- a/Day_20d/Day_20d.ino
+++ b/Day_20d/Day_20d.ino
@@ -1,0 +1,391 @@
+//Goal: recreate day 15 project using rotary encoder in the place of the keypad
+#include <TM1637Display.h>
+
+// Define the display connection pins:
+#define CLK 7
+#define DIO 6
+
+// Rotary Encoder Inputs
+#define CLK2 3
+#define DT2 4
+// Switch Input
+#define SW2 2
+
+//light sensor range is 0 - 671
+int sensorPin = A0; //select the *analog zero* input pin for probing the photoresistor 
+int senMax = 680; //maximum light value received by the sensor
+int buzzer = 8;  //sound output pin
+int redPin = 11;   //  PWM color output pins
+int greenPin = 10;
+int bluePin = 9;
+
+int access = 0;
+
+// Create display object of type TM1637Display:
+TM1637Display OurDisplay = TM1637Display(CLK, DIO);
+ 
+// Create array that turns all segments on:
+const uint8_t data[] = {0xff, 0xff, 0xff, 0xff};
+ 
+// Create array that turns all segments off:
+const uint8_t blank[] = {0x00, 0x00, 0x00, 0x00};
+ 
+int pw1 = 0;
+int pw2 = 0;
+int length = 1;
+int password = 2469;
+int multiplier = 10;
+
+int currentStateCLK;
+int lastStateCLK;
+ 
+//  custom function to process a login attempt *******************************
+ /*
+int unlockMode(){
+    char result ;
+    bool correctPass = true;
+ 
+    RGB_color(0, 0, 0); // turn LED OFF
+    //Serial.println("Unlock Mode: Type Password to continue");
+    delay(500);
+   
+    for(int i = 0; i < PassLength; i++) {
+       while(!(result = securityPad.getKey())) {
+         // wait indefinitely for keypad input of any kind
+       }
+       if(currentPassword[i] != result){     // a wrong key was pressed
+          correctPass = false;
+       }
+       Serial.print("*");  // print a phantom character for a successful keystroke
+       playInput();
+       RGB_color(0, 0, 125); // flash LED blue
+       delay(100);
+       RGB_color(0, 0, 0);
+    }  //  done after 4 characters are accepted
+
+    if (correctPass){   
+      Serial.println("");
+      Serial.println("Device Successfully Unlocked!");
+      // playSuccess();
+      return 0;           //  0 means succeeded
+    }
+    else {
+      Serial.println("");
+      Serial.println("WRONG PASSWORD");
+      //Serial.println(result);
+      // playError();
+      return -1;                    //  -1 means failed -- return immediately    
+    }
+
+} */
+ 
+//  custom functions to give audio feedback *******************************
+ 
+void playSuccess() {
+  RGB_color(0, 125, 0); // LED to GREEN
+  tone(buzzer, 1000, 200);
+  delay(200);
+  tone(buzzer, 2700, 1000);
+  delay(1000);
+  noTone(buzzer);
+  delay(1000);
+  RGB_color(0, 0, 0);
+}
+ 
+void playError() {
+  RGB_color(255, 0, 0); // LED to RED
+  tone(buzzer, 147, 1000);
+  delay(1000);
+  noTone(buzzer);
+  delay(1000);
+  RGB_color(0, 0, 0);
+}
+ 
+void playInput() {
+  tone(buzzer, 880, 200);
+  delay(50);
+  noTone(buzzer);
+}
+ 
+//  custom function to light the LED *******************************
+void RGB_color(int red_value, int green_value, int blue_value)
+{
+  analogWrite(redPin, red_value);
+  analogWrite(greenPin, green_value);
+  analogWrite(bluePin, blue_value);
+}
+ 
+//  ************************************************************************
+ 
+void setup() {
+  pinMode(redPin, OUTPUT);  // designate pins for PWM LED output
+  pinMode(greenPin, OUTPUT);
+  pinMode(bluePin, OUTPUT);
+
+  // Set encoder pins as inputs
+  pinMode(CLK2,INPUT);
+  pinMode(DT2,INPUT);
+  pinMode(SW2,INPUT_PULLUP);
+
+  pinMode(13, OUTPUT);
+ 
+  // Clear the display:
+  OurDisplay.clear();
+  delay(1000);
+  OurDisplay.setBrightness(7);
+
+  // Read the initial state of A (CLK)
+  lastStateCLK = digitalRead(CLK2);
+
+  // Call Interrupt Service Routine (ISR) updateEncoder() when any high/low change
+  // is seen on A (CLK2) interrupt  (pin 2), or B (DT2) interrupt (pin 3)
+  //hardware interrupts are only available on pins 2 and 3
+  attachInterrupt(digitalPinToInterrupt(CLK2), updateEncoder, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(SW2), record, CHANGE);
+
+  RGB_color(125, 125, 125);  //set LED to white on startup...
+  delay(2000);
+  RGB_color(0, 0, 0);  //... and off again
+ 
+  Serial.begin(9600); // Begin monitoring via the serial monitor
+  delay(2000);
+  // Serial.println("Enter password to access the system:");
+  // Serial.println("Press * to set a new password.");
+  // Serial.println("Press # to access the system with the existing one.");
+
+  Serial.println("Enter password to access the system:");
+
+}
+
+void showMenu(){
+  Serial.println("Enter an option:");
+  Serial.println("1: Light In Controls Sound Pitch");
+  Serial.println("2: Light In Controls Light Out");
+  Serial.println("3: Change Password");
+  Serial.println("9: Exit");
+}
+/*
+void passwordChange() {
+    for(int i = 0; i < PassLength; i++) {
+    while(!(result = securityPad.getKey())) {
+    // wait indefinitely for keypad input of any kind
+    }
+
+    currentPassword[i] = result;
+    Serial.print("*");    // print a phantom character for a successful keystroke
+    playInput();
+    RGB_color(0, 0, 125); // flash LED blue
+    delay(100);
+    RGB_color(0, 0, 0);
+  }   //  done after 4 characters are accepted
+
+  Serial.println("");
+  Serial.println("Password Successfully Changed!");
+  RGB_color(0, 125, 0); // LED to GREEN
+  delay(2000);
+  RGB_color(0, 0, 0);
+
+}
+
+void menuOptA(){
+  int sensorValue = 0;
+  int buzzTone = 100;
+  float senPercent = 0.0;
+  Serial.println("Press any key to return to menu.");
+  while(!(result = securityPad.getKey())) {
+    // run photo sound operation until a key is pressed
+    sensorValue = analogRead(sensorPin);
+    senPercent = (float)sensorValue / (float)senMax;
+    buzzTone = int(senPercent * 4000);
+    // Serial.print("Sensor: ");
+    // Serial.print(sensorValue);
+    // Serial.print("  Tone: ");
+    // Serial.print(buzzTone);
+    // Serial.print("  Should be: ");
+    // Serial.println(senPercent);
+    tone(buzzer, buzzTone, 100);
+    delay(10);
+    noTone(buzzer);
+    delay(10);
+  }
+  return;
+}
+
+void menuOptB(){
+  int sensorValue = 0;
+  int lightLevel = 0;
+  float senPercent = 0.0;
+  int redLevel;
+  int greenLevel;
+  int blueLevel;
+  Serial.println("Press any key to return to menu.");
+  while(!(result = securityPad.getKey())) {
+    // run photo sound operation until a key is pressed
+    sensorValue = analogRead(sensorPin);
+    senPercent = (float)sensorValue / (float)senMax;
+    lightLevel = int(senPercent * 255);
+
+    //Test variables
+    // Serial.print("Sensor: ");
+    // Serial.print(sensorValue);
+    // Serial.print("  Tone: ");
+    // Serial.print(lightLevel);
+    // Serial.print("  Should be: ");
+    // Serial.println(senPercent);
+
+    //Option 1: increasing red for the first third, green for the middle, blue for the last 
+    // if(lightLevel < 33){
+    //   redLevel = ((float)lightLevel / 32.0) * 100;
+    //   RGB_color(redLevel, 0, 0);
+    // }
+    // if(lightLevel >= 33 && lightLevel < 66){
+    //   greenLevel = (((float)lightLevel - 32.0) / 33.0) * 100;
+    //   RGB_color(0, greenLevel, 0);
+    // }
+    // if(lightLevel >= 66){
+    //   blueLevel = (((float)lightLevel - 65.0) / 35.0) * 100;
+    //   RGB_color(0, 0, blueLevel);
+    // }
+    
+    //Option 2: all white light
+    RGB_color(lightLevel, lightLevel, lightLevel);
+
+  }
+  RGB_color(0,0,0);
+  return;
+} */
+
+void loop() {
+ 
+OurDisplay.showNumberDec(pw1,true,length,0);
+delay(10);
+  //debuging readout 
+    // Serial.print("pw1: ");
+    // Serial.print(pw1);
+    // Serial.print("  length: ");
+    // Serial.print(length);
+    // Serial.print("  password: ");
+    // Serial.print(password);
+    // Serial.print("  multiplier: ");
+    // Serial.print(multiplier);
+    // Serial.print("  access: ");
+    // Serial.println(access);
+
+  if (access > 0){
+    //Serial.println("You have entered the menu");
+    showMenu();
+  }
+
+  while (access > 0) {           // enter menu mode
+    //result = securityPad.getKey(); 
+    /*
+    Serial.println("In the menu loop"); 
+    while(!(result = securityPad.getKey())) {
+         // wait indefinitely for keypad input of any kind
+       }
+    //Serial.println(result);
+    if (result == 'A'){
+      //Serial.println("This is option A.");
+      menuOptA();
+      showMenu();
+    }
+    if (result == 'B'){
+      //Serial.println("This is option B");
+      menuOptB();
+      showMenu();
+    }
+    if (result == 'C'){
+      Serial.println("Enter the new password:");
+      passwordChange();
+      showMenu();
+    }
+    if (result == '9'){
+      access = -1;
+      Serial.println("Exiting the system");
+    } */
+  }
+}
+ 
+//  This is our ISR which has the job of responding to interrupt events
+void updateEncoder(){
+  // Read the current state of CLK
+  currentStateCLK = digitalRead(CLK2);
+ 
+  // If last and current state of CLK are different, then a pulse occurred;
+  // React to only 0->1 state change to avoid double counting
+  if (currentStateCLK != lastStateCLK  && currentStateCLK == 1){
+ 
+    // If the DT state is different than the CLK state then
+    // the encoder is rotating CW so INCREASE counter by 1
+    if (digitalRead(DT2) == currentStateCLK) {
+      if((pw1 - (pw2 * multiplier)) == 9){
+        pw1 = pw2 * multiplier;
+      }
+      else {
+        pw1 ++;
+      }
+     
+    } else {
+      // Encoder is rotating CCW so DECREASE counter by 1
+      if(pw1 == (pw2 * multiplier)){
+        pw1 = pw1 + 9;
+      }
+      else {
+        pw1 --;
+      }
+    }
+ 
+    // Serial.print("Direction: ");
+    // Serial.print(currentDir);
+    // Serial.print(" | Counter= ");
+    // Serial.println(counter);
+  }
+ 
+  // Remember last CLK state to use on next interrupt...
+  lastStateCLK = currentStateCLK;
+}
+
+//function makes onboard LED flash when button is pushed
+void record(){
+    Serial.println(digitalRead(SW2));
+  if (digitalRead(SW2) == LOW){
+    Serial.println("in loop");
+    pw2 = pw1;
+    //multiplier = multiplier * 10;
+
+    if (length == 4){ //entering of password complete, validate if correct
+      //pw1 = pw2;
+      //length = 4;
+      if (pw1 == password){
+        Serial.println("Look Good");
+        access = 1;
+        OurDisplay.clear();
+      }
+      else {
+        Serial.println("Fuck off imposter!");
+        Serial.println("Enter the correct password to access the system:");
+        pw1 = 0;
+        pw2 = 0;
+        length = 1;
+        OurDisplay.clear();
+        return;
+      }
+    }
+
+    if (length < 4) {
+    length ++;
+    pw1 = pw1 * multiplier;
+    }
+  //debuging readout 
+    Serial.print("pw1: ");
+    Serial.print(pw1);
+    Serial.print("  pw2: ");
+    Serial.print(pw2);
+    Serial.print("  length: ");
+    Serial.print(length);
+    Serial.print("  password: ");
+    Serial.print(password);
+    Serial.print("  multiplier: ");
+    Serial.println(multiplier);
+  }
+}


### PR DESCRIPTION
Day_20d - Took longer than hoped.  Replaced keypad with rotary encoder because I didn't have enough inputs to do what I wanted with the keypad.  

Day_20a, Day_20b, and Day_20c were used to evolve features to final state.

launch.json was created when I was trying to quickly enable debugging.  Needs more research to get it working.

- Enter password with rotary encoder with seven segmant display to see numbers.
- After password verification, 4 menu options presented
- Option A plays a sound depending on how much light is being received by photoresister
- Option B varies LED output based on light received by photoresister
- Option C is used for password reset
- Option E exits the system, and restarts cycle by asking for the password again.